### PR TITLE
Requiring login to tag a subject, comment, thumbs up/down, flag/unflag

### DIFF
--- a/backend/src/main/java/com/example/subjecthub/api/SubjectServiceApi.java
+++ b/backend/src/main/java/com/example/subjecthub/api/SubjectServiceApi.java
@@ -31,6 +31,7 @@ public interface SubjectServiceApi {
         @RequestParam(required = false) String instructor
     );
 
+    @PreAuthorize("hasAuthority('USER')")
     @RequestMapping(value = "/subject/{subjectId}/addTag", method = RequestMethod.POST)
     public Subject addTagToSubject(@PathVariable Long universityId, @PathVariable Long subjectId, @RequestBody Tag tag);
 
@@ -60,6 +61,7 @@ public interface SubjectServiceApi {
         @PathVariable Long commentId
     );
 
+    @PreAuthorize("hasAuthority('USER')")
     @RequestMapping(value = "/subject/{subjectId}/comments/comment/add", method = RequestMethod.POST)
     public SubjectComment commentAdd(
         @PathVariable Long universityId,
@@ -67,6 +69,7 @@ public interface SubjectServiceApi {
         @RequestBody AddCommentRequest addCommentRequest
     );
 
+    @PreAuthorize("hasAuthority('USER')")
     @RequestMapping(value = "/subject/{subjectId}/comments/comment/{commentId}/addThumbUp", method = RequestMethod.GET)
     public SubjectComment commentAddThumbUp(
         @PathVariable Long universityId,
@@ -74,6 +77,7 @@ public interface SubjectServiceApi {
         @PathVariable Long commentId
     );
 
+    @PreAuthorize("hasAuthority('USER')")
     @RequestMapping(value = "/subject/{subjectId}/comments/comment/{commentId}/addThumbDown", method = RequestMethod.GET)
     public SubjectComment commentAddThumbDown(
         @PathVariable Long universityId,
@@ -81,6 +85,7 @@ public interface SubjectServiceApi {
         @PathVariable Long commentId
     );
 
+    @PreAuthorize("hasAuthority('USER')")
     @RequestMapping(value = "/subject/{subjectId}/comments/comment/{commentId}/flag", method = RequestMethod.GET)
     public SubjectComment commentFlag(
         @PathVariable Long universityId,
@@ -88,6 +93,7 @@ public interface SubjectServiceApi {
         @PathVariable Long commentId
     );
 
+    @PreAuthorize("hasAuthority('USER')")
     @RequestMapping(value = "/subject/{subjectId}/comments/comment/{commentId}/unflag", method = RequestMethod.GET)
     public SubjectComment commentUnflag(
         @PathVariable Long universityId,

--- a/backend/src/main/java/com/example/subjecthub/entity/Subject.java
+++ b/backend/src/main/java/com/example/subjecthub/entity/Subject.java
@@ -81,8 +81,10 @@ public class Subject {
     @JsonIgnoreProperties(value = {"subject"})
     private List<SubjectComment> comments;
 
-
     public Subject() {
+        this.comments = new ArrayList<>();
+        this.assessments = new ArrayList<>();
+        this.tags = new ArrayList<>();
     }
 
     public Long getId() {
@@ -205,8 +207,6 @@ public class Subject {
     public void setAssessments(List<Assessment> assessments) {
         this.assessments = assessments;
     }
-
-
 
     public List<Tag> getTags() {
         return tags;

--- a/backend/src/main/java/com/example/subjecthub/security/SecurityUserService.java
+++ b/backend/src/main/java/com/example/subjecthub/security/SecurityUserService.java
@@ -29,6 +29,7 @@ public class SecurityUserService implements UserDetailsService {
         if (subjectHubUser.isPresent()) {
             SubjectHubUser user = subjectHubUser.get();
             Set<GrantedAuthority> authorities = new HashSet<>();
+            authorities.add(new SimpleGrantedAuthority("USER"));
             if (user.getAdmin()) {
                 authorities.add(new SimpleGrantedAuthority("ADMIN"));
             }

--- a/backend/src/main/java/com/example/subjecthub/utils/Utils.java
+++ b/backend/src/main/java/com/example/subjecthub/utils/Utils.java
@@ -1,0 +1,15 @@
+package com.example.subjecthub.utils;
+
+import com.example.subjecthub.exception.SubjectHubException;
+import org.springframework.http.HttpStatus;
+
+import javax.annotation.Nullable;
+
+public class Utils {
+
+    public static void ifNull404(@Nullable Object o, String message) {
+        if (o == null) {
+            throw new SubjectHubException(HttpStatus.NOT_FOUND, message);
+        }
+    }
+}

--- a/backend/src/test/java/com/example/subjecthub/testutils/UrlUtils.java
+++ b/backend/src/test/java/com/example/subjecthub/testutils/UrlUtils.java
@@ -1,0 +1,40 @@
+package com.example.subjecthub.testutils;
+
+public class UrlUtils {
+
+    public static final String API_URL = "/api";
+
+    public static String buildUniApiUrl(Long uniId) {
+        return API_URL + "/universities/university/"  + uniId;
+    }
+
+    public static String buildSubjectsApiUrl(Long uniId) {
+        // /api/universities/university/{uniId}/subjects
+        return buildUniApiUrl(uniId) + "/subjects";
+    }
+
+    public static String buildSubjectApiUrl(Long uniId, Long subjectId) {
+        // /api/universities/university/{uniId}/subjects/subject/{subjectId}
+        return buildSubjectsApiUrl(uniId) + "/subject/" + subjectId;
+    }
+
+    public static String buildCommentsApiUrl(Long uniId, Long subjectId) {
+        // /api/universities/university/{uniId}/subjects/subject/{subjectId}/comments
+        return buildSubjectApiUrl(uniId, subjectId) + "/comments";
+    }
+
+    public static String buildCommentApiUrl(Long uniId, Long subjectId, Long commentId) {
+        // /api/universities/university/{uniId}/subjects/subject/{subjectId}/comments/comment/{commentId}
+        return buildCommentsApiUrl(uniId, subjectId) + "/comment/" + commentId;
+    }
+
+    public static String buildAssessmentsApiUrl(Long uniId, Long subjectId) {
+        // /api/universities/university/{uniId}/subjects/subject/{subjectId}/assessments
+        return buildSubjectApiUrl(uniId, subjectId) + "/assessments";
+    }
+
+    public static String buildAssessmentApiUrl(Long uniId, Long subjectId, Long assessmentId) {
+        // /api/universities/university/{uniId}/subjects/subject/{subjectId}/assessments/assessment/{assessmentId}
+        return buildAssessmentsApiUrl(uniId, subjectId) + "/assessment/" + assessmentId;
+    }
+}


### PR DESCRIPTION
- User must be authenticated to add a tag, comment, flag/unflag, thumbs up/down a comment
- Modified Subject so that empty List fields return as 0 length lists instead of null
- Returning 404 when trying to get a non-existant Subject or SubjectComment
- Subjects without comments return an empty list instead of 404
- Added UrlUtils making it easier to hit controller endpoints