### PR TITLE
Using Aspect's for parent object existance for child controllers and added admin endpoints for UniversityController

### DIFF
--- a/backend/src/main/java/com/example/subjecthub/api/UniversityServiceApi.java
+++ b/backend/src/main/java/com/example/subjecthub/api/UniversityServiceApi.java
@@ -9,12 +9,16 @@ import java.util.List;
 @ParametersAreNonnullByDefault
 public interface UniversityServiceApi {
 
-    public List<University> getUniversities(
+    List<University> getUniversities(
         @Nullable String abbreviation,
         @Nullable String name
     );
 
-    public University getUniversity(
+    University getUniversity(
+        Long universityId
+    );
+
+    void deleteUniversity(
         Long universityId
     );
 }

--- a/backend/src/main/java/com/example/subjecthub/api/UniversityServiceApi.java
+++ b/backend/src/main/java/com/example/subjecthub/api/UniversityServiceApi.java
@@ -1,24 +1,20 @@
 package com.example.subjecthub.api;
 
 import com.example.subjecthub.entity.University;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
 
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
 
-@RequestMapping("/api/universities")
+@ParametersAreNonnullByDefault
 public interface UniversityServiceApi {
 
-    @RequestMapping(value = "", method = RequestMethod.GET)
     public List<University> getUniversities(
-        @RequestParam(required = false) String abbreviation,
-        @RequestParam(required = false) String name
+        @Nullable String abbreviation,
+        @Nullable String name
     );
 
-    @RequestMapping(value = "university/{universityId}", method = RequestMethod.GET)
     public University getUniversity(
-        @PathVariable Long universityId
+        Long universityId
     );
 }

--- a/backend/src/main/java/com/example/subjecthub/controller/FacultyController.java
+++ b/backend/src/main/java/com/example/subjecthub/controller/FacultyController.java
@@ -32,7 +32,7 @@ public class FacultyController {
     }
 
     @RequestMapping(value = "/faculty/{facultyId}", method = RequestMethod.GET)
-    private Faculty getFaculty(
+    public Faculty getFaculty(
         @PathVariable Long universityId,
         @PathVariable Long facultyId
     ) {

--- a/backend/src/main/java/com/example/subjecthub/controller/UniversityController.java
+++ b/backend/src/main/java/com/example/subjecthub/controller/UniversityController.java
@@ -4,16 +4,19 @@ import com.example.subjecthub.api.UniversityServiceApi;
 import com.example.subjecthub.entity.University;
 import com.example.subjecthub.repository.UniversityRepository;
 import com.example.subjecthub.utils.FuzzyUtils;
+import com.example.subjecthub.utils.Utils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @RestController
 @ParametersAreNonnullByDefault
-@CrossOrigin(origins = "http://localhost:4200")
+@CrossOrigin(origins = "*")
+@RequestMapping("/api/universities")
 public class UniversityController implements UniversityServiceApi {
 
     @Autowired
@@ -22,8 +25,8 @@ public class UniversityController implements UniversityServiceApi {
     @Override
     @RequestMapping(value = "", method = RequestMethod.GET)
     public List<University> getUniversities(
-        @RequestParam(required = false) String abbreviation,
-        @RequestParam(required = false) String name
+        @RequestParam(required = false) @Nullable String abbreviation,
+        @RequestParam(required = false) @Nullable String name
     ) {
         return universityRepository.findAll().stream()
             .filter(u -> abbreviation == null || FuzzyUtils.isSimilar(abbreviation, u.getAbbreviation()))
@@ -36,6 +39,8 @@ public class UniversityController implements UniversityServiceApi {
     public University getUniversity(
         @PathVariable Long universityId
     ) {
-        return universityRepository.findOne(universityId);
+        University u = universityRepository.findOne(universityId);
+        Utils.ifNull404(u, "University not found.");
+        return u;
     }
 }

--- a/backend/src/main/java/com/example/subjecthub/controller/UniversityController.java
+++ b/backend/src/main/java/com/example/subjecthub/controller/UniversityController.java
@@ -1,11 +1,13 @@
 package com.example.subjecthub.controller;
 
+import com.example.subjecthub.Application;
 import com.example.subjecthub.api.UniversityServiceApi;
 import com.example.subjecthub.entity.University;
 import com.example.subjecthub.repository.UniversityRepository;
 import com.example.subjecthub.utils.FuzzyUtils;
 import com.example.subjecthub.utils.Utils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import javax.annotation.Nullable;
@@ -42,5 +44,16 @@ public class UniversityController implements UniversityServiceApi {
         University u = universityRepository.findOne(universityId);
         Utils.ifNull404(u, "University not found.");
         return u;
+    }
+
+    @Override
+    @PreAuthorize("hasAuthority('ADMIN')")
+    @RequestMapping(value ="university/{universityId}", method = RequestMethod.DELETE)
+    public void deleteUniversity(
+        @PathVariable Long universityId
+    ) {
+        University u = getUniversity(universityId);
+        Application.log.info("Deleting {}.", u);
+        universityRepository.delete(u);
     }
 }

--- a/backend/src/main/java/com/example/subjecthub/entity/Faculty.java
+++ b/backend/src/main/java/com/example/subjecthub/entity/Faculty.java
@@ -1,10 +1,13 @@
 package com.example.subjecthub.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "faculties")
@@ -27,10 +30,16 @@ public class Faculty {
     @JsonIgnore
     private University university;
 
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "faculty", orphanRemoval = true)
+    @JsonIgnore
+    private List<Subject> subjects;
+
     public Faculty() {
+        this.subjects = new ArrayList<>();
     }
 
     public Faculty(String name, String code, University university) {
+        this();
         this.name = name;
         this.code = code;
         this.university = university;
@@ -67,6 +76,14 @@ public class Faculty {
 
     public void setUniversity(University university) {
         this.university = university;
+    }
+
+    public List<Subject> getSubjects() {
+        return subjects;
+    }
+
+    public void setSubjects(List<Subject> subjects) {
+        this.subjects = subjects;
     }
 
     @Override

--- a/backend/src/main/java/com/example/subjecthub/entity/Subject.java
+++ b/backend/src/main/java/com/example/subjecthub/entity/Subject.java
@@ -32,7 +32,7 @@ public class Subject {
     @ManyToOne
     @JoinColumn(name = "faculty_id")
     // Ignoring the university field inside faculty. Unnecessary details since uni is known.
-    @JsonIgnoreProperties(value = {"university"})
+    @JsonIgnoreProperties(value = {"university", "subjects"})
     private Faculty faculty;
 
     @Column(nullable = false)

--- a/backend/src/main/java/com/example/subjecthub/entity/University.java
+++ b/backend/src/main/java/com/example/subjecthub/entity/University.java
@@ -9,6 +9,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -33,12 +34,13 @@ public class University {
     private List<Faculty> faculties;
 
     public University() {
-
+        this.faculties = new ArrayList<>();
     }
 
     public University(String name, String abbreviation) {
         this.name = name;
         this.abbreviation = abbreviation;
+        this.faculties = new ArrayList<>();
     }
 
     public Long getId() {

--- a/backend/src/main/java/com/example/subjecthub/entity/University.java
+++ b/backend/src/main/java/com/example/subjecthub/entity/University.java
@@ -1,12 +1,15 @@
 package com.example.subjecthub.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import javax.annotation.ParametersAreNonnullByDefault;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.JoinColumn;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import java.util.ArrayList;
@@ -29,8 +32,8 @@ public class University {
     @Column(nullable = false)
     private String abbreviation;
 
-    @OneToMany
-    @JoinColumn(name = "university_id")
+    @JsonIgnore
+    @OneToMany(cascade = CascadeType.ALL, mappedBy = "university", orphanRemoval = true)
     private List<Faculty> faculties;
 
     public University() {
@@ -38,9 +41,9 @@ public class University {
     }
 
     public University(String name, String abbreviation) {
+        this();
         this.name = name;
         this.abbreviation = abbreviation;
-        this.faculties = new ArrayList<>();
     }
 
     public Long getId() {

--- a/backend/src/main/java/com/example/subjecthub/repository/SubjectRepository.java
+++ b/backend/src/main/java/com/example/subjecthub/repository/SubjectRepository.java
@@ -10,4 +10,6 @@ public interface SubjectRepository extends CrudRepository<Subject, Long> {
     List<Subject> findByFaculty_University_Id(Long universityId);
 
     List<Subject> findByCodeContainingIgnoreCase(String code);
+
+    boolean exists(Long subjectId);
 }

--- a/backend/src/main/java/com/example/subjecthub/repository/UniversityRepository.java
+++ b/backend/src/main/java/com/example/subjecthub/repository/UniversityRepository.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 public interface UniversityRepository extends CrudRepository<University, Long> {
 
-    public List<University> findAll();
+    List<University> findAll();
 
+    boolean exists(Long universityId);
 }

--- a/backend/src/main/java/com/example/subjecthub/utils/UniversityExistsAspect.java
+++ b/backend/src/main/java/com/example/subjecthub/utils/UniversityExistsAspect.java
@@ -1,0 +1,59 @@
+package com.example.subjecthub.utils;
+
+import com.example.subjecthub.Application;
+import com.example.subjecthub.exception.SubjectHubException;
+import com.example.subjecthub.repository.SubjectRepository;
+import com.example.subjecthub.repository.UniversityRepository;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Configuration
+public class UniversityExistsAspect {
+
+    @Autowired
+    private UniversityRepository universityRepository;
+
+    @Autowired
+    private SubjectRepository subjectRepository;
+
+    @Before(
+        "execution(* com.example.subjecthub.controller.SubjectServiceController.getSubjects (..)) || " +
+        "execution(* com.example.subjecthub.controller.SubjectServiceController.getSubject (..)) || " +
+        "execution(* com.example.subjecthub.controller.FacultyController.getFaculties (..)) || "+
+        "execution(* com.example.subjecthub.controller.FacultyController.getFaculty (..)) || "+
+        "execution(* com.example.subjecthub.controller.AssessmentServiceController.getAssessment (..)) || " +
+        "execution(* com.example.subjecthub.controller.AssessmentServiceController.getAssessments (..)) || " +
+        "execution(* com.example.subjecthub.controller.CommentsServiceController.getComments (..)) || " +
+        "execution(* com.example.subjecthub.controller.CommentsServiceController.getComment (..))")
+    public boolean universityExists(JoinPoint joinPoint) {
+        Application.log.info("Checking if university exists.");
+        Long universityId = (Long) joinPoint.getArgs()[0];
+        if (!universityRepository.exists(universityId)) {
+            Application.log.info("Call to {} dropped because University was not found.",
+                joinPoint.getSignature());
+            throw new SubjectHubException(HttpStatus.NOT_FOUND, "University not found.");
+        }
+        return false;
+    }
+
+    @Before(
+            "execution(* com.example.subjecthub.controller.AssessmentServiceController.getAssessment* (..)) || " +
+            "execution(* com.example.subjecthub.controller.CommentsServiceController.getComment* (..))")
+    public boolean subjectExists(JoinPoint joinPoint) {
+        Application.log.info("Checking if subject exists.");
+        Long subjectId = (Long) joinPoint.getArgs()[1];
+        if (!subjectRepository.exists(subjectId)) {
+            Application.log.info("Call to {} dropped because Subject was not found.",
+                joinPoint.getSignature());
+            throw new SubjectHubException(HttpStatus.NOT_FOUND, "Subject not found.");
+        }
+        return false;
+    }
+}

--- a/backend/src/test/java/com/example/subjecthub/FacultyControllerTests.java
+++ b/backend/src/test/java/com/example/subjecthub/FacultyControllerTests.java
@@ -1,7 +1,5 @@
 package com.example.subjecthub;
 
-import com.example.subjecthub.api.UniversityServiceApi;
-import com.example.subjecthub.controller.FacultyController;
 import com.example.subjecthub.entity.Faculty;
 import com.example.subjecthub.entity.University;
 import com.example.subjecthub.repository.FacultyRepository;
@@ -16,8 +14,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
+import org.springframework.web.context.WebApplicationContext;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -30,14 +27,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class FacultyControllerTests {
 
     @Autowired
-    private FacultyController controller;
-
-    @Autowired
     private FacultyRepository facultyRepository;
 
     @Autowired
     private UniversityRepository universityRepository;
 
+    @Autowired
+    private WebApplicationContext webApplicationContext;
 
     private MockMvc mockMvc;
     private University university;
@@ -45,7 +41,7 @@ public class FacultyControllerTests {
     @Before
     public void setUp() throws Exception {
         mockMvc = MockMvcBuilders
-            .standaloneSetup(controller)
+            .webAppContextSetup(webApplicationContext)
             .build();
 
         this.university = universityRepository.findAll().get(0);

--- a/backend/src/test/java/com/example/subjecthub/UniversityControllerTests.java
+++ b/backend/src/test/java/com/example/subjecthub/UniversityControllerTests.java
@@ -1,24 +1,35 @@
 package com.example.subjecthub;
 
 import com.example.subjecthub.controller.UniversityController;
+import com.example.subjecthub.entity.Faculty;
+import com.example.subjecthub.entity.Subject;
 import com.example.subjecthub.entity.University;
-import com.example.subjecthub.exception.ExceptionAdvice;
 import com.example.subjecthub.repository.FacultyRepository;
 import com.example.subjecthub.repository.UniversityRepository;
+import com.example.subjecthub.testutils.EntityUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static com.example.subjecthub.testutils.UrlUtils.buildFacultiesApiUrl;
+import static com.example.subjecthub.testutils.UrlUtils.buildSubjectsApiUrl;
 import static com.example.subjecthub.testutils.UrlUtils.buildUniApiUrl;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -40,13 +51,18 @@ public class UniversityControllerTests {
     @Autowired
     FacultyRepository facultyRepository;
 
+    @Autowired
+    EntityUtils entityUtils;
+
+    @Autowired
+    WebApplicationContext webApplicationContext;
+
     private MockMvc mockMvc;
 
     @Before
     public void setUp() throws Exception {
         mockMvc = MockMvcBuilders
-            .standaloneSetup(controller)
-            .setControllerAdvice(new ExceptionAdvice())
+            .webAppContextSetup(webApplicationContext)
             .build();
     }
 
@@ -84,7 +100,6 @@ public class UniversityControllerTests {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.name", is("testUni")))
             .andExpect(jsonPath("$.abbreviation", is("TU")))
-            .andExpect(jsonPath("$.faculties", hasSize(0)))
             .andReturn();
     }
 
@@ -113,7 +128,7 @@ public class UniversityControllerTests {
         String[] names =
             {"UnIveRsiTY of teStiNg", "university of testing", "UNIVERSITY OF TESTING"};
 
-        for (String universityName: names) {
+        for (String universityName : names) {
             mockMvc.perform(get("/api/universities?name=" + universityName))
                 .andExpect(jsonPath("$", hasSize(1)))
                 .andExpect(jsonPath("$[0].name", is("University of Testing")))
@@ -135,11 +150,83 @@ public class UniversityControllerTests {
             .andExpect(jsonPath("$.message", is("University not found.")));
     }
 
+    @Test
+    @WithMockUser(authorities = {"ADMIN"})
+    public void testDeleteUniversity() throws Exception {
+        University u = createUniversity("Delete University", "DT");
+
+        Faculty f1 = new Faculty("Faculty 1", "F1", u);
+        Faculty f2 = new Faculty("Faculty 2", "F2", u);
+
+        Subject f1s1 = entityUtils.createSubject("f1 sub1", "F1S1", f1);
+        Subject f1s2 = entityUtils.createSubject("f1 sub2", "F1S2", f1);
+        Subject f2s1 = entityUtils.createSubject("f2 sub1", "F2S1", f2);
+
+        List<Subject> faculty1Subjects = new ArrayList<>(Arrays.asList(f1s1, f1s2));
+        List<Subject> faculty2Subjects = new ArrayList<>(Collections.singletonList(f2s1));
+
+        f1.setSubjects(faculty1Subjects);
+        f2.setSubjects(faculty2Subjects);
+
+        List<Faculty> testFaculties = new ArrayList<>(Arrays.asList(f1, f2));
+
+        facultyRepository.save(testFaculties);
+        u.setFaculties(testFaculties);
+        u = universityRepository.save(u);
+
+        String uniUrl = buildUniApiUrl(u.getId());
+        String subjectsUrl = buildSubjectsApiUrl(u.getId());
+
+        // Test that the uni we created appears in the universities list
+        mockMvc.perform(get("/api/universities"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasSize(3)))
+            .andExpect(jsonPath("$[2].name", is("Delete University")));
+
+        // Test that three 3 subjects we created appear in the list
+        mockMvc.perform(get(subjectsUrl))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasSize(3)))
+            .andExpect(jsonPath("$[0].name", is("f1 sub1")))
+            .andExpect(jsonPath("$[1].name", is("f1 sub2")))
+            .andExpect(jsonPath("$[2].name", is("f2 sub1")));
+
+        mockMvc.perform(delete(uniUrl))
+            .andExpect(status().isOk());
+
+        // Test can't get university
+        mockMvc.perform(get(uniUrl))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message", is("University not found.")));
+
+        // Test can't get faculties for university
+        mockMvc.perform(get(buildFacultiesApiUrl(u.getId())))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message", is("University not found.")));
+
+        // Test can't get subjects for university
+        mockMvc.perform(get(subjectsUrl))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message", is("University not found.")));
+
+        mockMvc.perform(get("/api/universities"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$", hasSize(2)));
+    }
+
+    @Test
+    @WithMockUser(authorities = {"USER"})
+    public void testUserCantDeleteUniversity() throws Exception {
+        mockMvc.perform(delete(buildUniApiUrl(1L)))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.message", is("Access is denied")));
+    }
+
     /**
      * Util test method that handles extraneous params for creating university objects.
      */
     private University createUniversity(String name, String abbreviation) {
-        University testUniversity  = new University();
+        University testUniversity = new University();
         testUniversity.setName(name);
         testUniversity.setAbbreviation(abbreviation);
         return universityRepository.save(testUniversity);

--- a/backend/src/test/java/com/example/subjecthub/testutils/UrlUtils.java
+++ b/backend/src/test/java/com/example/subjecthub/testutils/UrlUtils.java
@@ -8,6 +8,16 @@ public class UrlUtils {
         return API_URL + "/universities/university/"  + uniId;
     }
 
+    public static String buildFacultiesApiUrl(Long uniId) {
+        // /api/universities/university/{uniId}/faculties
+        return buildUniApiUrl(uniId) + "/faculties";
+    }
+
+    public static String buildFacultyApiUrl(Long uniId, Long facultyId) {
+        // /api/universities/university/{uniId}/faculties/faculty/{facultyId}
+        return buildFacultiesApiUrl(uniId) + "/faculty/" + facultyId ;
+    }
+
     public static String buildSubjectsApiUrl(Long uniId) {
         // /api/universities/university/{uniId}/subjects
         return buildUniApiUrl(uniId) + "/subjects";


### PR DESCRIPTION
- Removed controller specific annotations from UniversityServiceApi
- Returning 404 if university cannot be found
- Returning empty faculty list instead of null when serializing University
- Refactored tests to help improve readability
- Controllers that rely on the existance of a parent will automatically be checked for the existance of the parent using Aspects
- Faculty, Subject, Assessment, and Comments controllers require that a parent University exist
- Assessment and Comments controllers require that a parent Subject exist
- Added delete endpoint for university
- Added cascading delete for university
- Added tests for new university functionality (will add tests for other controllers soon)